### PR TITLE
Added isRequiredBy

### DIFF
--- a/model/src/main/java/org/cloudml/core/RelationshipInstance.java
+++ b/model/src/main/java/org/cloudml/core/RelationshipInstance.java
@@ -124,6 +124,10 @@ public class RelationshipInstance extends WithResources implements DeploymentEle
     public boolean isProvidedBy(ComponentInstance<? extends Component> candidateServer) {
         return getServerComponent().equals(candidateServer);
     }
+    
+    public boolean isRequiredBy(ComponentInstance<? extends Component> candidateClient) {
+    	return getClientComponent().equals(candidateClient);
+    }
 
     public boolean eitherEndIs(PortInstance<? extends Port> port) {
         return getProvidedEnd().equals(port) || getRequiredEnd().equals(port);


### PR DESCRIPTION
Small change to enable ability to check if RelationshipInstance has an instance of Port that belongs to ComponentInstance (candidateClient), as a requiredEnd.