### PR TITLE
Fix in VM-memory calculation for CloudSigma

### DIFF
--- a/connectors/src/main/java/org/cloudml/connectors/CloudSigmaConnector.java
+++ b/connectors/src/main/java/org/cloudml/connectors/CloudSigmaConnector.java
@@ -199,7 +199,7 @@ public class CloudSigmaConnector implements Connector {
 
         org.jclouds.cloudsigma2.domain.ServerInfo serverToCreate = new org.jclouds.cloudsigma2.domain.ServerInfo.Builder()
                 .name(a.getName())
-                .memory(BigInteger.valueOf(vm.getMinRam() * 1000000))
+                .memory(BigInteger.valueOf(vm.getMinRam()).multiply(BigInteger.valueOf(1024*1024)))
                 .vncPassword("cloudml")
                 .cpu(vm.getMinCores())
                 .nics(ImmutableList.of(nic))


### PR DESCRIPTION
Hi Nicolas,

a small fix for the memory calculation...

Also one thing we could consider is change the way CPU requirements are calculated for CloudSigma. Currently the minCores property is passed to the CloudSigma API where GHz is expected. So what we could do is use minCores for real cores in the deployment model and multiply it with 2500 before passing it to jClouds. This would result in typical cores available there.

Cheers,
Stepan